### PR TITLE
Robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,12 @@ the message as serialized by Protobuf. The receiving side checks for these field
 and will deserialize the message, after which it can be processed by the
 application.
 
-To send or receive messages, the message first needs to be registered on both sides
-with `registerMessageType()`. Most importantly, the ID passed to this method is
-needed since it is part of the wire protocol. This ID should be the same both on the
-sender and on the receiver side, otherwise the message type cannot be properly
-determined. The message type ID can be freely chosen, except that `0` is reserved as
-it is used for keep alive messages.
+To send or receive messages, the message first needs to be registered on both
+sides with a call to `registerMessageType()`. Please note that the first
+parameter (type ID) is used to determine the message type on the receiving end,
+therefore it must correspond on both ends. The message type ID can be any
+positive (signed) integer larger than 0; type ID 0 is reserved for keep-alive
+messages.
 
 Origin of the Name
 ==================

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -100,6 +100,20 @@ void Socket::connect(const std::string& address, int port)
     d->thread = new std::thread([&]() { d->run(); });
 }
 
+void Socket::reset()
+{
+	if (d->state != SocketState::Closed &&
+		d->state != SocketState::Error)
+		return;
+
+	d->thread->join();
+
+	d->state = SocketState::Initial;
+	d->nextState = SocketState::Initial;
+	d->partialMessage = nullptr;
+	d->errorString = "";
+}
+
 void Socket::listen(const std::string& address, int port)
 {
     d->address = address;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -20,6 +20,7 @@
 #include "Socket_p.h"
 
 #include <algorithm>
+#include <typeinfo>
 
 using namespace Arcus;
 
@@ -61,6 +62,9 @@ void Socket::registerMessageType(int type, const google::protobuf::Message* mess
     {
         return;
     }
+
+    if(type <= 0)
+    	throw new std::bad_typeid();
 
     d->messageTypes[type] = messageType;
     d->messageTypeMapping[messageType->GetDescriptor()] = type;

--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -35,7 +35,10 @@ Socket::~Socket()
         if(d->state != SocketState::Closed || d->state != SocketState::Error)
         {
             d->nextState = SocketState::Closing;
-            d->thread->join();
+        	if(d->thread) {
+        		d->thread->join();
+        		d->thread = nullptr;
+        	}
         }
         delete d->thread;
     }
@@ -106,7 +109,10 @@ void Socket::reset()
 		d->state != SocketState::Error)
 		return;
 
-	d->thread->join();
+	if(d->thread) {
+		d->thread->join();
+		d->thread = nullptr;
+	}
 
 	d->state = SocketState::Initial;
 	d->nextState = SocketState::Initial;
@@ -125,7 +131,10 @@ void Socket::listen(const std::string& address, int port)
 void Socket::close()
 {
     d->nextState = SocketState::Closing;
-    d->thread->join();
+	if(d->thread) {
+		d->thread->join();
+		d->thread = nullptr;
+	}
 }
 
 void Socket::sendMessage(MessagePtr message)

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -122,6 +122,11 @@ namespace Arcus
         */
         MessagePtr takeNextMessage();
 
+        /**
+         * Reset a socket for re-use. State must be Closed or Error
+         */
+        void reset();
+
     private:
         const std::unique_ptr<SocketPrivate> d;
     };

--- a/src/Socket.h
+++ b/src/Socket.h
@@ -68,7 +68,7 @@ namespace Arcus
         *
         * If the socket state is not SocketState::Initial, this method will do nothing.
         *
-        * \param type An integer ID to use to identify the message.
+        * \param type An integer ID larger than 0 to use to identify the message.
         * \param messageType An instance of the Message that will be used as factory object.
         *
         * \note The `type` parameter should be the same both on the sender and receiver side.

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -238,7 +238,9 @@ namespace Arcus
 
                     receiveNextMessage();
 
-                    checkConnectionState();
+                    if (nextState != SocketState::Error)
+                    	checkConnectionState();
+
                     break;
                 }
                 case SocketState::Closing:

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -32,6 +32,7 @@
     #include <netinet/in.h>
     #include <arpa/inet.h>
     #include <unistd.h>
+	#include <signal.h>
 #endif
 
 #include <google/protobuf/message.h>
@@ -134,6 +135,10 @@ namespace Arcus
     // This is run in a thread.
     void SocketPrivate::run()
     {
+#ifndef _WIN32
+    	signal(SIGPIPE, SIG_IGN);
+#endif
+
         while(state != SocketState::Closed && state != SocketState::Error)
         {
             switch(state)

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -67,7 +67,7 @@ namespace Arcus
         sockaddr_in createAddress();
         void sendMessage(MessagePtr message);
         void receiveNextMessage();
-        int32_t readInt32();
+        int readInt32(int32_t *dest);
         int readBytes(int size, char* dest);
         void handleMessage(int type, int size, char* buffer);
         void setSocketReceiveTimeout(int socketId, int timeout);
@@ -310,17 +310,11 @@ namespace Arcus
             return;
         }
 
-        messageType = readInt32();
-        if(messageType <= 0)
-        {
+        if(readInt32(&messageType) || messageType <= 0)
             return;
-        }
 
-        messageSize = readInt32();
-        if(messageSize < 0)
-        {
+        if(readInt32(&messageSize) || messageSize < 0)
             return;
-        }
 
         try {
         	buffer = new char[messageSize];
@@ -342,7 +336,7 @@ namespace Arcus
         }
     }
 
-    int32_t SocketPrivate::readInt32()
+    int SocketPrivate::readInt32(int32_t *dest)
     {
         int32_t buffer;
         size_t num = ::recv(socketId, reinterpret_cast<char*>(&buffer), 4, 0);
@@ -351,7 +345,8 @@ namespace Arcus
             return -1;
         }
 
-        return ntohl(buffer);
+        *dest = ntohl(buffer);
+        return 0;
     }
 
     int SocketPrivate::readBytes(int size, char* dest)


### PR DESCRIPTION
This is the first series of patches aimed at improving robustness of libArcus. It facilitates the following
- Enforcement of the message type ID > 0 requirement
- Reset() functionality to re-use the socket (so we can re-listen without jumping through all the hoops)
- Various error checks and socket handling changes on the receiving side to gracefully handle connection problems (by closing the connection rather than crashing the server application)
- Attempt to improve documentation a little

This patch-set is not extensive and there's more on my todo-list, but does let me reliably run a server. Tested with communication between my desktop computer and an Olimex ARM board. Should not have any backwards-compatibility problems. Please review and merge.
