### PR TITLE
compile error with the newest protobuf git version

### DIFF
--- a/examples/example.proto
+++ b/examples/example.proto
@@ -9,8 +9,8 @@ message ObjectList {
 message Object {
     int32 id = 1;
     bytes vertices = 2; //An array of 3 floats.
-    optional bytes normals = 3; //An array of 3 floats.
-    optional bytes indices = 4; //An array of ints.
+    bytes normals = 3; //An array of 3 floats.
+    bytes indices = 4; //An array of ints.
 }
 
 message ProgressUpdate {


### PR DESCRIPTION
compile error with the newest protobuf git version:

example.proto:12:14: Explicit 'optional' labels are disallowed in the Proto3 syntax. To define 'optional' fields in Proto3, simply remove the 'optional' label, as fields are 'optional' by default.
example.proto:13:14: Explicit 'optional' labels are disallowed in the Proto3 syntax. To define 'optional' fields in Proto3, simply remove the 'optional' label, as fields are 'optional' by default.