### PR TITLE
Fix PYTHON_SITE_PACKAGES_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(Protobuf ${REQUIRED_PROTOBUF_VERSION} REQUIRED)
 
 if(INSTALL_PYTHON_PACKAGE)
     find_package(PythonInterp 3.0.0 REQUIRED)
-    set(PYTHON_SITE_PACKAGES_DIR ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages CACHE PATH "Install location of Python package")
+    set(PYTHON_SITE_PACKAGES_DIR ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/dist-packages CACHE PATH "Install location of Python package")
 endif()
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.1)


### PR DESCRIPTION
While doing packaging for libArcus I found out that the python module was installed to:
/usr/lib/x86_64-linux-gnu/python3.4/dist-packages/Arcus

This commit should fix that problem.