### PR TITLE
Fix compilation with NOSIGNAL

### DIFF
--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -48,6 +48,10 @@
 #define ARCUS_SIGNATURE 0x2BAD
 #define SIG(n) (((n) & 0xffff0000) >> 16)
 
+#ifndef MSG_NOSIGNAL
+	#define MSG_NOSIGNAL 0x4000 //Do not generate SIGPIPE.
+#endif
+
 /**
  * Private implementation details for Socket.
  */

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -49,7 +49,7 @@
 #define SIG(n) (((n) & 0xffff0000) >> 16)
 
 #ifndef MSG_NOSIGNAL
-	#define MSG_NOSIGNAL 0x4000 //Do not generate SIGPIPE.
+	#define MSG_NOSIGNAL 0x0 //Don't request NOSIGNAL on systems where this is not implemented.
 #endif
 
 /**


### PR DESCRIPTION
We currently use MSG_NOSIGNAL to request the remote party not to send SIGPIPE interrupts. But this macro is only defined in Linux environments. So as a workaround, let's define this macro ourselves if it is not yet defined. According to [this page](http://lxr.free-electrons.com/source/include/linux/socket.h#L273) it is defined as 0x4000. It might not do anything on other machines, but it will compile on all operating systems.

But I can't test this on all operating systems, so rather than committing it to libArcus itself, I'm making it a pull request so it can be tested separately.

Fixes Ultimaker/cura-build#15.