### PR TITLE
fix linking error on osx 10.11

### DIFF
--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "Error.h"
+#include <iostream>
 
 using namespace Arcus;
 


### PR DESCRIPTION
There was a linking problem like:
Undefined symbols for architecture x86_64:
  "std::__1::basic_ostream<char, std::__1::char_traits<char> >& std::__1::operator<<<char, std::__1::char_traits<char>, std::__1::allocator<char> >(std::__1::basic_ostream<char, std::__1::char_traits<char> >&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const ...
The solution came from:
http://stackoverflow.com/questions/31055492/why-clang-causes-error
