### PR TITLE
CMake: examples: Remove directory inclusion

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,6 +1,3 @@
-
-include_directories(example ${CMAKE_CURRENT_BINARY_DIR})
-
 set(example_SRCS
     example.cpp
     example_pb2.py


### PR DESCRIPTION
I guess this has been copy/pasted when this part of the code was in /CMakeLists.txt.
Having this left shows a warning, but doesn't break the build. However I think this can be savely removed.
