### PR TITLE
Give include priority to the SIP include path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(BUILD_PYTHON)
     else()
         set(PYTHON_SITE_PACKAGES_DIR lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages CACHE STRING "Directory to install Python bindings to")
     endif()
-    include_directories(python/ src/ ${PYTHON_INCLUDE_DIR} ${SIP_INCLUDE_DIR})
+    include_directories(python/ src/ ${SIP_INCLUDE_DIR} ${PYTHON_INCLUDE_DIR})
 endif()
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.1)


### PR DESCRIPTION
This causes an issue with cura-build if a newer SIP version is installed on the system,
then the python include path would take precedence and Arcus would require
a newer SIP API than the one that comes bundled with cura.

This will finally get rid of this error if sip 4.18 is installed locally while Arcus gets compiled by the cura-build script : 
```
An uncaught exception has occurred!
Traceback (most recent call last):
  File "./bin/cura2", line 47, in <module>
    import Arcus #@UnusedImport
Runtime Error: the sip module implements API v11.0 to v11.2 but the Arcus module requires API v11.3
```
