### PR TITLE
Hide Socket::Private explicitly

### DIFF
--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -72,7 +72,7 @@ namespace Arcus
 {
     using namespace Private;
 
-    class Socket::Private
+    class ARCUS_NO_EXPORT Socket::Private
     {
     public:
         Private()


### PR DESCRIPTION
This is a fix for #101 .