### PR TITLE
fix deprecated protobuf calls

### DIFF
--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -128,9 +128,6 @@ namespace Arcus
 
         static const int keep_alive_rate = 500; //Number of milliseconds between sending keepalive packets
 
-        // This value determines when protobuf should warn about very large messages.
-        static const int message_size_warning = 400 * 1048576;
-
         // This value determines when protobuf should error out because the message is too large.
         // Due to the way Protobuf is implemented, messages large than 512MiB will cause issues.
         static const int message_size_maximum = 500 * 1048576;
@@ -362,7 +359,7 @@ namespace Arcus
             return;
         }
 
-        uint32_t message_size = message->ByteSize();
+        uint32_t message_size = message->ByteSizeLong();
         if(platform_socket.writeUInt32(message_size) == -1)
         {
             error(ErrorCode::SendFailedError, "Could not send message size");
@@ -548,7 +545,7 @@ namespace Arcus
 
         google::protobuf::io::ArrayInputStream array(wire_message->data, wire_message->size);
         google::protobuf::io::CodedInputStream stream(&array);
-        stream.SetTotalBytesLimit(message_size_maximum, message_size_warning);
+        stream.SetTotalBytesLimit(message_size_maximum);
         if(!message->ParseFromCodedStream(&stream))
         {
             error(ErrorCode::ParseFailedError, "Failed to parse message:" + std::string(wire_message->data));


### PR DESCRIPTION
```
libArcus-4.8.0/src/Socket_p.h:365:51: warning: ‘int google::protobuf::MessageLite::ByteSize() const’ is deprecated: Please use ByteSizeLong() instead [-Wdeprecated-declarations]
  365 |         uint32_t message_size = message->ByteSize();
```

and 

```
libArcus-4.8.0/src/Socket_p.h:551:77: warning: ‘void google::protobuf::io::CodedInputStream::SetTotalBytesLimit(int, int)’ is deprecated: Please use the single parameter version of SetTotalBytesLimit(). The second parameter is ignored. [-Wdeprecated-declarations]
  551 |         stream.SetTotalBytesLimit(message_size_maximum, message_size_warning);
```