### PR TITLE
Allow Cmake to use FindPython3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,10 +24,18 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON) #Required if a patch to libArcus needs t
 if(BUILD_PYTHON)
     list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 
-    # FIXME: Use FindPython3 to find Python, new in CMake 3.12.
-    # However currently on our CI server it finds the wrong Python version and then doesn't find the headers.
-    find_package(PythonInterp 3.4 REQUIRED)
-    find_package(PythonLibs 3.4 REQUIRED)
+    # FIXME: Remove the code for CMake <3.12 once we have switched over completely.
+    # FindPython3 is a new module since CMake 3.12. It deprecates FindPythonInterp and FindPythonLibs.
+    if(${CMAKE_VERSION} VERSION_LESS 3.12)
+        # FIXME: Use FindPython3 to find Python, new in CMake 3.12.
+        # However currently on our CI server it finds the wrong Python version and then doesn't find the headers.
+        find_package(PythonInterp 3.4 REQUIRED)
+        find_package(PythonLibs 3.4 REQUIRED)
+
+    else()
+        # Use FindPython3 for CMake >=3.12
+        find_package(Python3 3.4 COMPONENTS Interpreter Development)
+    endif()
 
     find_package(SIP REQUIRED)
     if(NOT DEFINED LIB_SUFFIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ if(BUILD_PYTHON)
 
     else()
         # Use FindPython3 for CMake >=3.12
-        find_package(Python3 3.4 COMPONENTS Interpreter Development)
+        find_package(Python3 3.4 REQUIRED COMPONENTS Interpreter Development)
     endif()
 
     find_package(SIP REQUIRED)


### PR DESCRIPTION
This allows us to use FindPython3 if the cmake version
is higher or equal to 3.12. Which allows a user to set
`-DPython3_FIND_VIRTUALENV=ONLY` such that the library
can be installed in a virtual environment (mostly
useful on Mac and Windows machines). This commit
doesn't break the current behavior of our CI machines.

This will also make this repository future ready when we finally
do update cmake.