### PR TITLE
Fixing package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To build the python bindings (default on, disable with -DBUILD_PYTHON=OFF) these
 On Ubuntu 20.04 this can be achieved with:
 
 ```
-sudo apt install build-essentials cmake python3-dev python3-sip-dev protobuf-compiler libprotoc-dev libprotobuf-dev
+sudo apt install build-essential cmake python3-dev python3-sip-dev protobuf-compiler libprotoc-dev libprotobuf-dev
 ```
 
 Building the library can be done with:


### PR DESCRIPTION
build-essentials -> build-essential