### PR TITLE
Fix build failure when using UNICODE / _UNICODE on Windows

### DIFF
--- a/src/PlatformSocket.cpp
+++ b/src/PlatformSocket.cpp
@@ -47,7 +47,7 @@ sockaddr_in createAddress(const std::string& address, int port)
     sockaddr_in a;
     a.sin_family = AF_INET;
 #ifdef _WIN32
-    InetPton(AF_INET, address.c_str(), &(a.sin_addr)); // Note: Vista and higher only.
+    InetPtonA(AF_INET, address.c_str(), &(a.sin_addr)); // Note: Vista and higher only.
 #else
     ::inet_pton(AF_INET, address.c_str(), &(a.sin_addr));
 #endif


### PR DESCRIPTION
Per the *UTF-8 Everywhere Manifesto*, it's best to not rely on the legacy ANSI .vs UNICODE macros for Win32 functions that take strings. Since you explicitly use a ``std::string`` for the call to ``InetPton`` you should explicitly use the ``InetPtonA`` method.

> This causes problems when trying to build your library using vcpkg manager when the setup adds the recommended UNICODE _UNICODE defines.
