### PR TITLE
CURA-11103 Fail sending a message that is too big to be parsed

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "5.4.0-alpha.0"
+version: "5.4.1"

--- a/include/Arcus/Error.h
+++ b/include/Arcus/Error.h
@@ -28,6 +28,8 @@ enum class ErrorCode
     InvalidStateError, ///< Socket is in an invalid state.
     InvalidMessageError, ///< Message being handled is a nullptr or otherwise invalid.
     Debug, // Debug messages
+
+    // When changing this list, don't forget to apply the same changes on pyArcus/python/Error.sip
 };
 
 /**

--- a/include/Arcus/Error.h
+++ b/include/Arcus/Error.h
@@ -19,6 +19,7 @@ enum class ErrorCode
     BindFailedError, ///< Bind to IP and port failed.
     AcceptFailedError, ///< Accepting an incoming connection failed.
     SendFailedError, ///< Sending a message failed.
+    MessageTooBigError, ///< Sending a message failed because it was too big.
     ReceiveFailedError, ///< Receiving a message failed.
     UnknownMessageTypeError, ///< Received a message with an unknown message type.
     ParseFailedError, ///< Parsing the received message failed.

--- a/include/Arcus/Socket.h
+++ b/include/Arcus/Socket.h
@@ -114,7 +114,7 @@ public:
     /**
      * Send a message across the socket.
      */
-    virtual void sendMessage(MessagePtr message);
+    virtual bool sendMessage(MessagePtr message);
 
     /**
      * Remove and return the next pending message from the queue with condition blocking.

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -341,7 +341,7 @@ void Socket::Private::sendMessage(const MessagePtr& message)
     const uint32_t message_size = message->ByteSizeLong();
     if (message_size > message_size_maximum)
     {
-        error(ErrorCode::SendFailedError, "Message is too big to be sent");
+        error(ErrorCode::MessageTooBigError, "Message is too big to be sent");
         return;
     }
 

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -43,7 +43,7 @@
 #define VERSION_MINOR 0
 
 #define ARCUS_SIGNATURE 0x2BAD
-#define SIG(n) (((n)&0xffff0000) >> 16)
+#define SIG(n) (((n) & 0xffff0000) >> 16)
 
 #define SOCKET_CLOSE 0xf0f0f0f0
 
@@ -360,7 +360,11 @@ void Socket::Private::sendMessage(const MessagePtr& message)
     }
 
     std::string data = message->SerializeAsString();
-    if (platform_socket.writeBytes(data.size(), data.data()) == -1)
+    if (data.size() > message_size_maximum)
+    {
+        error(ErrorCode::SendFailedError, "Message is too big to be sent");
+    }
+    else if (platform_socket.writeBytes(data.size(), data.data()) == -1)
     {
         error(ErrorCode::SendFailedError, "Could not send message data");
     }

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -338,13 +338,6 @@ void Socket::Private::run()
 // Send a message to the connected socket.
 void Socket::Private::sendMessage(const MessagePtr& message)
 {
-    const uint32_t message_size = message->ByteSizeLong();
-    if (message_size > message_size_maximum)
-    {
-        error(ErrorCode::MessageTooBigError, "Message is too big to be sent");
-        return;
-    }
-
     const uint32_t header = (ARCUS_SIGNATURE << 16) | (VERSION_MAJOR << 8) | (VERSION_MINOR);
     if (platform_socket.writeUInt32(header) == -1)
     {
@@ -352,6 +345,7 @@ void Socket::Private::sendMessage(const MessagePtr& message)
         return;
     }
 
+    const uint32_t message_size = message->ByteSizeLong();
     if (platform_socket.writeUInt32(message_size) == -1)
     {
         error(ErrorCode::SendFailedError, "Could not send message size");


### PR DESCRIPTION
When sending a message, we now check that the actual message size is not too big, otherwise the message will be sent but we won't be able to parse it on the receiver side. Now we fail earlier so that the front-end can detect it properly.

CURA-11103