### PR TITLE
Add missing stdint includes

### DIFF
--- a/include/Arcus/MessageTypeStore.h
+++ b/include/Arcus/MessageTypeStore.h
@@ -5,6 +5,7 @@
 #define ARCUS_MESSAGE_TYPE_STORE_H
 
 #include <memory>
+#include <cstdint>
 
 #include "Arcus/Types.h"
 

--- a/include/Arcus/Types.h
+++ b/include/Arcus/Types.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 namespace google
 {

--- a/src/MessageTypeStore.cpp
+++ b/src/MessageTypeStore.cpp
@@ -6,6 +6,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_map>
+#include <cstdint>
 
 #include <google/protobuf/compiler/importer.h>
 #include <google/protobuf/dynamic_message.h>

--- a/src/PlatformSocket.cpp
+++ b/src/PlatformSocket.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) 2022 Ultimaker B.V.
 // libArcus is released under the terms of the LGPLv3 or higher.
 
+#include <cstdint>
+
 #include "PlatformSocket_p.h"
 
 #ifdef _WIN32

--- a/src/PlatformSocket_p.h
+++ b/src/PlatformSocket_p.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 namespace Arcus
 {

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -12,6 +12,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <cstdint>
 
 #ifdef _WIN32
 #include <winsock2.h>

--- a/src/WireMessage_p.h
+++ b/src/WireMessage_p.h
@@ -4,6 +4,8 @@
 #ifndef ARCUS_WIRE_MESSAGE_P_H
 #define ARCUS_WIRE_MESSAGE_P_H
 
+#include <cstdint>
+
 #include "Arcus/Types.h"
 
 namespace Arcus

--- a/test_package/src/test.cpp
+++ b/test_package/src/test.cpp
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <iostream>
 #include <thread>
+#include <cstdint>
 
 #include "test.h"
 


### PR DESCRIPTION
Arcus uses C stdint types in several places, but the source code is missing stdint.h/cstdint includes.
This causes build errors when they aren't pulled in by some other dependency, in particular with gcc 15.

I added a `#include <cstdint>` in all source files where it's needed.