### PR TITLE
Added includes for the chrono library

### DIFF
--- a/src/Socket.cpp
+++ b/src/Socket.cpp
@@ -5,6 +5,7 @@
 #include "Socket_p.h"
 
 #include <algorithm>
+#include <chrono>
 
 using namespace Arcus;
 

--- a/src/Socket_p.h
+++ b/src/Socket_p.h
@@ -4,6 +4,7 @@
 #ifndef SOCKET_P_H
 #define SOCKET_P_H
 
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <iostream>


### PR DESCRIPTION
Something appears to have changed in one of the more recent versions of MSVC and the Windows builds for Arcus broke. It seems that while Arcus was using the chrono library, Microsoft's compiler will no longer allow for implicit use of this library and requires that the include statement be present.

This change appears to fix the build errors and allows for a successful windows build.