### PR TITLE
[CURA-12675] workaround for anti-virus forcing version of DLL on Cura

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -136,9 +136,6 @@ class ArcusConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
-
-        cmake.compiler_definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
-
         cmake.configure()
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -119,6 +119,9 @@ class ArcusConan(ConanFile):
 
     def generate(self):
         tc = CMakeToolchain(self)
+
+        tc.preprocessor_definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
+
         if is_msvc(self):
             tc.variables["USE_MSVC_RUNTIME_LIBRARY_DLL"] = not is_msvc_static_runtime(self)
         tc.cache_variables["CMAKE_POLICY_DEFAULT_CMP0077"] = "NEW"
@@ -133,6 +136,9 @@ class ArcusConan(ConanFile):
 
     def build(self):
         cmake = CMake(self)
+
+        cmake.definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
+
         cmake.configure()
         cmake.build()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -137,7 +137,7 @@ class ArcusConan(ConanFile):
     def build(self):
         cmake = CMake(self)
 
-        cmake.definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
+        cmake.compiler_definitions["_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR"] = 1
 
         cmake.configure()
         cmake.build()


### PR DESCRIPTION
The dynamic lib `MSVCP140.dll` (and related) comes in two distinct flavours -- one pre-fix and one post-fix -- according to MS this _technically_ doesn't break compatibility and is 'By Design'. (But it's not _really_ them that are to blame in this particular case.)

In any case, this was a bit of a problem for us -- but one we thought to have (eventually, after some detours) solved with the workaround of just building everything with the newer version and then forcing the newer ones to be high up in our `PATH`.

Que certain anti-virus vendors (McAfee) just straight up forcing programs to use certain DLL's -- which is a can of worms just in and of itself, and from the above context you can begin to guess which particular worm bit _us_ in this case.

Yes, that's right, they're forcing us to use the _old_ version of `MSVCP140.dll`.

Fortunately, MS was at least graceful enough to have 'an escape hatch' as they put it, so that's what we're using here. Even though we _actually_ shouldn't need it, since we where using the newer version (originally).

Anyway we should be good now, whatever version of that DLL anyone has.