### PR TITLE
Fix compilation with newer protobuf versions

### DIFF
--- a/src/MessageTypeStore.cpp
+++ b/src/MessageTypeStore.cpp
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <string_view>
 #include <unordered_map>
 
 #include <google/protobuf/compiler/importer.h>
@@ -19,10 +20,10 @@ using namespace Arcus;
  * of std::hash differs between compilers, we need to make sure we use the same
  * implementation everywhere.
  */
-uint32_t hash(const std::string& input)
+uint32_t hash(std::string_view input)
 {
-    const char* data = input.c_str();
-    uint32_t length = input.size();
+    const char* data = input.data();
+    uint32_t length = static_cast<uint32_t>(input.size());
     uint32_t result = static_cast<uint32_t>(2166136261UL);
     for (; length; --length)
     {
@@ -39,7 +40,7 @@ public:
     {
     }
 
-    void AddError(const std::string& filename, int line, int column, const std::string& message) override
+    void RecordError(absl::string_view filename, int line, int column, absl::string_view message) override
     {
         _stream << "[" << filename << " (" << line << "," << column << ")] " << message << std::endl;
         _error_count++;


### PR DESCRIPTION
This PR updates the function signatures of hash() and AddError() to use string_view and renames AddError to RecordError. In combination with #160 this builds successfully with up-to-date dependencies for me.